### PR TITLE
a 50-100 times faster neobinlister2

### DIFF
--- a/functions/neobinlister2_fast.m
+++ b/functions/neobinlister2_fast.m
@@ -1,0 +1,792 @@
+%  neobinlister2_fast
+%  
+%  This function mimics the behavior of ERPLAB's neobinlister2.
+%  Events are checked for whether they are in the right order, and for
+%  events that have time specification, it is checked whether they
+%  occur within the specified time-window and in the specified order.
+%  It does, however, not yet allow RT measurement, forbidden/ignoreCodeArray
+%  input should be handled with caution, and it's unclear whether flags are
+%  treated as they should be.
+%  However, tested on a dataset containing 20.000 events, the output is exactly
+%  the same as with neobinlister2, and speed-up is in the range of 50-100 times.
+%  
+%  Code adapted and new subfunction 'checkBINfnc' added
+%  by Christoph Huber-Huber, Feb 2018.
+% 
+%
+%  Legacy help text for neobinlister2 below. Although it says "beta version"
+%  at some point, neobinlister2 is the default in many standard ERPLAB 
+%  situations.
+%  
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% 
+%  BINLISTER IX 2010
+%
+%  binlister2.m is the Matlab  re-written version of the original Ecdbl from
+%  ERPSS.  It takes a log file for a given set of data and a bin  descriptor
+%  file  containing  specification  defining  the conditions  & contigencies
+%  an event should satisfy to be included in a particular average (bin), and
+%  produces  a  binlist  file that contains a list of  bins for each item in
+%  the log  file into  which the corresponding  raw  data  trial  should  be
+%  averaged. It also generates a BINLIST structure  which is currently  added  to
+%  the EEGLAB structure (optional).
+%
+%  Note: beta version.  Only for testing purpose. March  2009
+%  Write erplab at command window for help
+%
+% Usage:
+% >> [EEG EVENTLIST binOfBins] = binlister(EEG, bdfilename, eventlistFile,
+% neweventlistFile, forbiddenCodeArray, username)
+%
+% Inputs:
+%
+% EEG                - input dataset
+% eventlistFile          - name of EventList text file to load (optional). Default='none'
+% neweventlistFile       - name of the new EventList text file to save.
+% forbiddenCodeArray - prohibited eventcodes. For instance -99 for pauses.
+% username           - name of operator
+%
+%  Outputs:
+%
+% EEG         - output dataset
+% EVENTLIST   - EventList output structure (it was previously added to EEGLAB structure by pop_creaeventlist())
+% binOfBins   - successful bins counting. For histogram (for instance)
+%
+% Author: Javier Lopez-Calderon & Steven Luck
+% Center for Mind and Brain
+% University of California, Davis,
+% Davis, CA
+% 2009
+
+%b8d3721ed219e65100184c6b95db209bb8d3721ed219e65100184c6b95db209b
+%
+% ERPLAB Toolbox
+% Copyright ? 2007 The Regents of the University of California
+% Created by Javier Lopez-Calderon and Steven Luck
+% Center for Mind and Brain, University of California, Davis,
+% javlopez@ucdavis.edu, sjluck@ucdavis.edu
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%
+% Bakan! means "Great!" in chilean-slang.
+% pre-home means codes or sequence of codes before home code(s) (before .)
+% at-home (or just home) means code(s) to be the zero time locked code (first bracket after the .)
+% post-home means codes or sequence of codes after home code(s) (second bracket (and s0) after the . )
+% LES means LOG EVENT SELECTOR (prehome)
+
+
+function [EEG, EVENTLIST, binOfBins, isparsenum] = neobinlister2_fast(EEG, bdfilename, eventlistFile, neweventlistFile, forbiddenCodeArray, ignoreCodeArray, reportable, indexEL)
+
+binOfBins  = [];
+EVENTLIST  = [];
+isparsenum =1;
+
+if nargin < 1
+        help pop_binlister
+        return
+end
+if nargin < 8
+        indexEL = 1; % EVENTLIST index, in case of multiple EVENTLIST structures
+end
+if nargin < 7
+        reportable = 0; % do not create report (default)
+end
+if nargin < 6
+        ignoreCodeArray = [];
+end
+if nargin < 5
+        forbiddenCodeArray = [];
+end
+if nargin < 4
+        neweventlistFile = '';
+end
+if nargin < 3
+        eventlistFile = '';
+end
+if nargin < 2
+        error('ERPLAB says: neobinlister needs 2 inputs as least.')
+end
+
+% get erplab version
+version = geterplabversion;
+
+if isempty(bdfilename)
+        error('ERPLAB says: bdfilename is empty.')
+end
+if ismember(neweventlistFile,{'none', 'no', ''})        
+        p = which('eegplugin_erplab');
+        path_temp = p(1:findstr(p,'eegplugin_erplab.m')-1);
+        newevefilepath = fullfile(path_temp, 'erplab_Box');
+        if exist(newevefilepath, 'dir')~=7
+                mkdir(newevefilepath);  % Thanks to Johanna Kreither. Jan 31, 2013
+        end        
+        neweventlistFile = sprintf('eventlist_backup_%g', (datenum(datestr(now))*1e10));    %   ['eventlist_backup_' num2str((datenum(datestr(now))*1e10))];
+        neweventlistFile = fullfile(newevefilepath, neweventlistFile);
+end
+
+%
+% segments and parses bdf 03-05-2008
+%
+[BIN, nwrongbins] = decodebdf(bdfilename);
+if nwrongbins == 0
+        
+        %
+        % BDF Decoder.
+        % Converts BIN Descriptor into numeric parameters (struct).
+        %
+        [BIN, isparsenum] = bdf2struct(BIN);
+        
+        if isparsenum==0
+                % parsing was not approved
+                return
+        end
+else
+        isparsenum = 0; % parsing was not approved
+        return
+end
+
+%
+% Read EVENTLIST
+%
+if ismember(eventlistFile,{'none', 'no', ''}) % from dataset or erpset
+        if iserpstruct(EEG)
+                EVENTLIST = exporterpeventlist(EEG, indexEL);
+                fprintf('\n*** neobinlister is taking EVENTLIST from the current ERPset.\n\n')
+        else
+                [EEGx, EVENTLIST] = creaeventlist(EEG);
+                clear EEGx
+        end
+else % from text file
+        % Read EVENTLIST file into EEG.EVENTLIST.eventinfo (also EEG.EVENTLIST.bdf )
+        [EEGx, EVENTLIST] = readeventlist(EEG, eventlistFile); % ok
+        clear EEGx
+end
+
+%
+% Add bin descriptor structure to EVENTLIST struct
+%
+EVENTLIST.bdf = BIN;
+% fprintf('Detecting succesful BINs in the EVENTLIST.eventinfo structure....\n');
+
+%
+%  Open a new Bin List File
+%
+bdfcrono   = datestr(now, 'mmmm dd, yyyy HH:MM:SS AM');
+
+if reportable
+        
+        %
+        % Creates a Report about Binlister performance
+        %
+        [pr, namer] = fileparts(neweventlistFile);
+        auxrname = fullfile(pr,namer);
+        rnameAux = [auxrname '_REPORT.txt'];
+        fid_report  = fopen(rnameAux, 'w');
+        flinkname = rnameAux;
+        disp(['You can find a report about binlister processing at <a href="matlab: open(''' flinkname ''')">' flinkname '</a>'])
+else
+        fid_report  = 1;
+        rnameAux    = '';
+end
+
+%
+% Returns the user home directory using the registry on windows systems, and using Java
+% on non windows systems as a string.
+%
+if ispc
+        userdir = winqueryreg('HKEY_CURRENT_USER',...
+                ['Software\Microsoft\Windows\CurrentVersion\' ...
+                'Explorer\Shell Folders'],'Personal');
+        %
+        % Captures user login
+        %
+        userlogin  = regexprep(userdir, '.*\', '');
+else
+        userdir = char(java.lang.System.getProperty('user.home'));
+        
+        %
+        % Captures user login
+        %
+        userlogin  = regexprep(userdir, '.*/', '');
+end
+
+%
+% Number of BINs
+%
+nbin = length(BIN);
+
+%
+% Tracks successful bins (histogram)
+%
+binOfBins   = zeros(1,nbin);
+nitem       = length(EVENTLIST.eventinfo);
+% binrow      = []; % never used in this version, neobinlister2_fast (Christoph)
+
+%
+% Saves bin descriptor file name
+%
+EVENTLIST.bdfname = bdfilename;
+
+%
+% Saves setname for EEG work
+%
+if isfield(EEG,'setname')
+        if strcmpi(EEG.setname, '')
+                EVENTLIST.setname = 'no_data';
+        else
+                EVENTLIST.setname = EEG.setname;
+        end
+elseif isfield(EEG,'erpname')
+        if strcmpi(EEG.erpname, '')
+                EVENTLIST.setname = 'no_data';
+        else
+                EVENTLIST.setname = EEG.erpname;
+        end
+else
+        EVENTLIST.setname = 'no_data';
+end
+
+EVENTLIST.elname   = neweventlistFile;  % text output EVENTLIST
+EVENTLIST.report   = rnameAux;          % text output REPORT
+EVENTLIST.version  = version;
+EVENTLIST.eldate   = bdfcrono;
+EVENTLIST.account  = userlogin;
+% fprintf('\nHUNTING BINs...This process might take...');
+
+%
+% Set progress report at command window
+%
+fprintf('\n');
+fprintf([repmat('*',1, 45) '\n']);
+fprintf('**\n');
+msg = '** Binlister progress to completion......\n'; % carriage return included in case error interrupts loop
+fprintf(msg);
+ppaux=1;
+% tic;
+
+
+% coded for enhanced speed by Christoph, 2018-01.
+itemEnable = [EVENTLIST.eventinfo.enable];
+itemCodes = [EVENTLIST.eventinfo.code];
+itemTimes = [EVENTLIST.eventinfo.time] * 1000; % probably in seconds, convert to ms!
+
+% cd1:
+% Current (log) item status should not be forbidden (enable = -1) code
+cd1array = itemEnable ~= -1 & ~ismember_bc2(itemCodes, forbiddenCodeArray);
+
+% cd2:
+% Current event code should not be a ignored (enable = 0) code
+cd2array = itemEnable ~= 0 & ~ismember_bc2(itemCodes, ignoreCodeArray);
+
+% athome event codes
+atHomeCodes = unique(arrayfun(@(b) double(b.athome.eventcode), BIN));
+
+% numeric index to all home/time-locking events
+TLitemNumIdx = find(cd1array & cd2array & itemCodes ~= -99 & ...
+    ismember(itemCodes, atHomeCodes));
+
+
+% for iLogitem = 1:nitem  % Reads each log item (item pointer)
+% loop only through home code items (timelocking events, TL)
+for iLogitem = TLitemNumIdx
+    
+    %
+        % Progress report at command window
+        %
+        pp = round((iLogitem/nitem)*100);
+        if pp>=0 && mod(pp,5)==0 && ppaux~=pp
+                %                 if pp>1 && pp<10
+                %                         nstepback = 3;
+                %                 elseif pp>=10 && pp<100
+                %                         nstepback = 4;
+                %                 else
+                %                         nstepback = 5;
+                %                 end
+                numze = ceil(log10(pp + 1))-1; % number of zeros
+                nstepback = 3 + numze;
+                
+                fprintf([repmat('\b',1, nstepback) '%d%%\n'], pp);
+                ppaux=pp; % to avoid multiple printing for the same value
+        end
+        
+        
+        % check to which bin, or multiple bins, this item belongs
+        belongsToBins = [];
+        for jBin = 1:nbin
+            binok = checkBINfnc(iLogitem, itemCodes, itemTimes, BIN(jBin));
+            if binok
+                belongsToBins = [belongsToBins, jBin];
+                binOfBins(jBin) = binOfBins(jBin) + 1; % the counter for trials per bin
+            end
+        end
+        
+        if numel(belongsToBins) > 1
+            warning('Not clear whether an event can belong to more than one bin. Might be problem for epoching later on...');
+        end
+        
+        EVENTLIST.eventinfo(iLogitem).bini = belongsToBins;
+        
+        % assign bin number(s) to EVENTLIST
+        if isempty(belongsToBins) % no bin found
+            EVENTLIST.eventinfo(iLogitem).bini = -1;
+            % Creates BIN LABELS
+            binName = '""';
+        else % found a bin
+            EVENTLIST.eventinfo(iLogitem).bini = belongsToBins;
+            % Creates BIN LABELS
+            auxname = num2str(belongsToBins);
+            bname   = regexprep(auxname, '\s+', ',', 'ignorecase'); % inserts a comma instead blank space
+            
+            if strcmp(EVENTLIST.eventinfo(iLogitem).codelabel,'""')
+                binName = ['B' bname '(' num2str(EVENTLIST.eventinfo(iLogitem).code) ')']; %B#(code)
+            else
+                binName = ['B' bname '(' EVENTLIST.eventinfo(iLogitem).codelabel ')']; %B#(codelabel)
+            end
+        end
+        EVENTLIST.eventinfo(iLogitem).binlabel = binName;
+
+
+end  % Reads each log item (iLogitem loop)
+
+% assignin('base', 'tiemporesp', tiempostim);
+
+% pause(0.01)
+fprintf('\n');
+
+%
+%  Replace the old EVENT LIST (LOG) Text File Output
+%
+EVENTLIST.trialsperbin = binOfBins; % 07-21-2008
+EVENTLIST.nbin = nbin; % total number of specified bins (at bin descriptor file)
+
+%
+% Simplify bin descriptor expressions (Steve's request)
+%
+for i=1:nbin
+        expcell = EVENTLIST.bdf(i).expression;
+        EVENTLIST.bdf(i).expression = [expcell{1} '.' expcell{2} expcell{3}];
+end
+
+%
+%  Creates a EVENTLIST Text Output and updates EVENTLIST structure
+%
+if iserpstruct(EEG)
+        EVENTLIST = EEG.EVENTLIST(indexEL);
+        exporterpeventlist(EEG, indexEL, neweventlistFile);
+else
+        [EEGx, EVENTLIST] = creaeventlist(EEG, EVENTLIST, neweventlistFile);
+        clear EEGx
+end
+
+fprintf('Successful Trials per bin :\t%s\n', num2str(binOfBins));
+if reportable
+        fclose(fid_report);        % Closes the file where you wrote the report
+end
+
+
+
+%--------------------------------------------------------------------------------------------------------------------------------
+%
+%   Determine whether certain time-lock event belongs to certain bin
+% 
+function binok = checkBINfnc(iLogitem, itemCodes, itemTimes, B)
+    % The central function added by Christoph, Feb 2018.
+    
+    binok = false;
+    
+    preok = false;
+    postok = false;
+    
+    iLogitemTime = itemTimes(iLogitem);
+    ip = iLogitem - 1;
+    prehi = numel(B.prehome); % will move from last to first 'prehome' event
+    preTimeLimit = -1; % an event with 'timecode' can occur at max at this time
+    
+    % Actually twice almost exactly the same code, once for 'pre' and once
+    % for 'post'.
+    while ip > 0 && prehi > 0
+        % whats the "event sign"?
+        % (if more than one element, both usually the same)
+        if numel(unique(B.prehome(prehi).eventsign)) ~= 1, error('Unexpected case!'); end
+        thisPreSign = all(B.prehome(prehi).eventsign); % all 'eventsign' supposed to be the same
+        
+        % So, is time relevant?
+        currentTimeWindowPos = unique(B.prehome(prehi).timecode, 'rows');
+        currentTimeWindow = sort(-1 * currentTimeWindowPos);
+        % replace upper limit by 'preTimeLimit', to ensure that sequences
+        % of prehome expressions occur in the order in which they are
+        % specified.
+        currentTimeWindow(2) = min([preTimeLimit, currentTimeWindow(2)]);
+        
+        if size(currentTimeWindow, 1) ~= 1 % is not a row vector
+            % 'timecode' are not unique across all 'eventcodes'
+            % of the current 'prehome'. that's unexpected!
+            error('''timecode'' not unique across ''eventcodes'' of current ''prehome'' - how come?');
+        end
+        if all(unique(B.prehome(prehi).timecode, 'rows') >= 0) % time is relevant
+            % use B.prehome.timecode, since currentTimeWindow has been
+            % ajusted and might be negative although relevant!
+            % get index to all events in the time window
+            currentIdx = (itemTimes - iLogitemTime) >= currentTimeWindow(1) & ...
+                (itemTimes - iLogitemTime) <= currentTimeWindow(2);
+            currentCodes = itemCodes(currentIdx);
+            currentTimesAbs = itemTimes(currentIdx);
+            currentTimesRel = currentTimesAbs - iLogitemTime;
+            if thisPreSign % = 1
+                % there has to be an event of current prehome code
+                if any(ismember(currentCodes, B.prehome(prehi).eventcode))
+                    % all good
+                    % set a new time limit: the lowest time of all the
+                    % occuring prehome events
+                    preTimeLimit = min(currentTimesRel(ismember(currentCodes, B.prehome(prehi).eventcode)));
+                    % can go to next prehome
+                    prehi = prehi - 1;
+                else
+                    % condition violated
+                    return
+                end
+            else % thisPreSign == 0, the prehome event codes must not be there
+                if any(ismember(currentCodes, B.prehome(prehi).eventcode))
+                    return
+                else
+                    % they are not there
+                    % can go to next prehome
+                    prehi = prehi - 1;
+                    % but, keep the current time limit! if the time limit
+                    % was adjusted here to the maximum of the not-occurring
+                    % events (because of sign == 0!), it would be too
+                    % restrictive for the next time critical event!
+                end
+            end
+        else % time is _not_ relevant
+            % is current event an event code we are looking for?
+            if any(ismember(itemCodes(ip), B.prehome(prehi).eventcode))
+                % YES
+                % (if-statement could probably also be without 'ismember',
+                %  because itemCodes can only contain one element, right?)
+                prehi = prehi - 1; % also go to next prehome event
+                ip = ip - 1; % and go to next event/item
+            else % NO
+                return
+            end
+        end
+    end
+    
+    % all prehome events are satisfied
+    if prehi == 0
+        preok = true;
+    end
+    
+    % check posthome events
+    ip = iLogitem + 1;
+    posthi = 1;
+    postTimeLimit = 1;
+    while ip <= numel(itemCodes) && posthi <= numel(B.posthome)
+        % What sign does next event have?
+        % (if more than one element, both usually the same)
+        if numel(unique(B.posthome(posthi).eventsign)) ~= 1, error('Unexpected case!'); end
+        thisPostSign = all(B.posthome(posthi).eventsign);
+        % So, is time relevant?
+        currentTimeWindow = unique(B.posthome(posthi).timecode, 'rows');
+        currentTimeWindow(1) = max([currentTimeWindow(1), postTimeLimit]);
+        if size(currentTimeWindow, 1) ~= 1 % is not a row vector
+            % 'timecode' are not unique across all 'eventcodes'
+            % of the current 'posthome'. that's unexpected!
+            error('''timecode'' not unique across ''eventcodes'' of current ''posthome'' - home come?');
+        end
+        if all(unique(B.posthome(posthi).timecode, 'rows') >= 0) % time is relevant
+            % get index to all events in the time window
+            currentIdx = (itemTimes - iLogitemTime) >= currentTimeWindow(1) & ...
+                (itemTimes - iLogitemTime) <= currentTimeWindow(2);
+            currentCodes = itemCodes(currentIdx);
+            currentTimesAbs = itemTimes(currentIdx);
+            currentTimesRel = currentTimesAbs - iLogitemTime;
+            if thisPostSign % = 1
+                % there has to be an event of current posthome code
+                if any(ismember(currentCodes, B.posthome(posthi).eventcode))
+                    % set a new time limit: the largest time of all the
+                    % occuring prehome events
+                    postTimeLimit = max(currentTimesRel(ismember(currentCodes, B.posthome(posthi).eventcode)));
+                    % all good, can go to next posthome
+                    posthi = posthi + 1;
+                else
+                    % condition violated
+                    return
+                end
+            else % thisPostSign == 0, the posthome event codes must not be there
+                if any(ismember(currentCodes, B.posthome(posthi).eventcode))
+                    return
+                else
+                    % they are _not_ there, so can go to next posthome
+                    posthi = posthi + 1;
+                    % but, keep the current time limit! if the time limit
+                    % was adjusted here to the maximum of the not-occurring
+                    % events (because of sign == 0!), it would be too
+                    % restrictive for the next time critical event!
+                end
+            end
+        else % time is _not_ relevant
+            % is current event an event code we are looking for?
+            if any(ismember(itemCodes(ip), B.posthome(posthi).eventcode))
+                % YES
+                % (if-statement could probably also be without 'ismember',
+                %  because itemCodes can only contain one element, right?)
+                posthi = posthi + 1; % also go to next posthome event
+                ip = ip + 1; % and go to next event/item
+            else % NO
+                return
+            end
+        end
+    end
+    
+    % all posthome events are satisfied
+    if posthi == numel(B.posthome)+1
+        postok = true;
+    end
+    
+    if preok && postok
+        binok = true;
+    end
+
+% FUNCTION END
+
+
+%--------------------------------------------------------------------------------------------------------------------------------
+%
+% Flag Test Function
+%
+
+function [ishomeFlagdetected, varargout] = flagTest(BIN, EVENTLIST, auxles, seq, currentbin, currentlogitem)
+
+auxflag     = BIN(currentbin).(auxles)(seq).flagcode(1,1); % first flag sequencer
+auxflagmask = BIN(currentbin).(auxles)(seq).flagmask(1,1); % first flag logic-mask per sequencer
+
+if auxflagmask~=0
+        maskedEventFlag    = bitand(EVENTLIST.eventinfo(currentlogitem).flag, auxflagmask); % apply the mask
+        ishomeFlagdetected = ~isempty(find(auxflag == maskedEventFlag, 1));    % compare flag condition
+        flgx=1;                                                                % There is flag condition
+else
+        ishomeFlagdetected = 1;  % by default, because there was not flag condition
+        flgx = 0;                % There was not flag condition
+end
+varargout(1)= {flgx};
+
+%--------------------------------------------------------------------------------------------------------------------------------
+%
+% Write Test Function
+%
+function [writeflag, writeindx] = writeTest(BIN, EVENTLIST, auxles, seq, currentbin,...
+        currentlogitem, writeflag, writeindx)
+
+auxwrite     = BIN(currentbin).(auxles)(seq).writecode(1,1); % first flag sequencer
+auxwritemask = BIN(currentbin).(auxles)(seq).writemask(1,1); % first flag logic-mask per sequencer
+
+if auxwritemask~=0
+        flagnegmasked    = bitand(EVENTLIST.eventinfo(currentlogitem).flag, bitcmp(auxwritemask)); % apply the complemented write mask
+        newflag = bitor(flagnegmasked, auxwrite );  % Bitwise OR between write setting and the current sequencer's flag
+        writeflag = [writeflag newflag];
+        writeindx = [writeindx currentlogitem];
+end
+
+%--------------------------------------------------------------------------------------------------------------------------------
+%
+% PREHOME & POSTHOME TIME-RANGE TEST 02
+%
+
+function[targetLogPointer, isdetectedLES, writeflag, writeindx, offsetLogitem] = timetest2(EVENTLIST, BIN, les, isnegated, previous_t2, ...
+        iLogitem, traffic, islastsequencer, writeflag, writeindx, jBin, kles, mSeq, offsetLogitem, forbiddenCodeArray, targetLogPointer, targetEventCodeArray)
+
+% I) The basic detection said there was no event code that matches,
+% but there is a description of time range for a non-negated code.
+% II) Or the basic detection said that there was an event code that mached, but
+% there is a description of the time range for a negated code.
+% III) Code match, but we need to check the specified time range.
+% *Remember that isdetectedLES = 0 for non-negated and isdetectedLES = 1 for negated
+
+%
+%         PREHOME & POSTHOME TIME-RANGE TEST 02
+%  timetest = 1;  % means TIME-RANGE TEST was required
+%
+%
+% Report: start time-range test 02
+%
+nitem = length(EVENTLIST.eventinfo);
+tempi = BIN(jBin).(les{kles})(mSeq).timecode(1,1:2);
+
+%
+% home-referenced time window  [t1 t2]
+%
+t1   = EVENTLIST.eventinfo(iLogitem).time + traffic(kles)*tempi(1,2^(2-kles))/1000 ;
+t2   = EVENTLIST.eventinfo(iLogitem).time + traffic(kles)*tempi(1,kles)/1000;
+
+if t2 > previous_t2 && kles==1
+        t2 = previous_t2;
+elseif t1 < previous_t2  && kles==2
+        t1 = previous_t2;
+end
+
+%
+%                     Forbidden's event detector
+%
+%
+t0        = EVENTLIST.eventinfo(iLogitem).time;
+rfrbddn   = find([EVENTLIST.eventinfo.time] >= t0 & [EVENTLIST.eventinfo.time] <= t2) ;
+
+if ~isempty(rfrbddn)
+        codesrangefrbddn  = [EVENTLIST.eventinfo(rfrbddn).code];
+        timecodesfrbddn   = [EVENTLIST.eventinfo(rfrbddn).time];
+        [tf, rp2]         = ismember_bc2(codesrangefrbddn, forbiddenCodeArray);
+        timefrbddn        = timecodesfrbddn(find(rp2,1));
+        codefrbddn        = codesrangefrbddn(find(rp2,1));
+        isfrbddndetected  = nnz(tf)>0;  % 1 means forbidden code(s) was(were) found within [t0 t2] time range.
+else
+        isfrbddndetected  = 0;
+end
+
+targetLogItemArray  = find([EVENTLIST.eventinfo.time] >= t1 & [EVENTLIST.eventinfo.time] <= t2); % items for events within T1-T2
+
+if ~isempty(targetLogItemArray)
+        targetLogCodeArray = [EVENTLIST.eventinfo(targetLogItemArray).code];      % LOGCODES within targetLogItemArray range
+        targetLogTimeArray = [EVENTLIST.eventinfo(targetLogItemArray).time];      % Log times within targetLogItemArray range (T1 - T2)
+        tf   = ismember(targetLogCodeArray, targetEventCodeArray);
+        rcr  = find(tf,1,'first'); % local pointer!
+        israngedetected = ~isempty(rcr);
+else
+        israngedetected = 0;
+end
+
+
+%*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+%*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+%*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+
+if israngedetected && isfrbddndetected   % Codes were detected but there was a pause code 04 February 2008
+        timecodOK = targetLogTimeArray(rcr);
+        targetLogPointer = targetLogItemArray(rcr);
+        
+        if (timefrbddn >= timecodOK && kles==1) || (timefrbddn <= timecodOK && kles==2)
+                % the pause was between the home and the current code...bad news
+                % Oops! Event code was preceded by a forbiden code.
+                isdetectedLES = 0;
+        else
+                if isnegated   % 02-21-2008
+                        % We have a problem...event code was found inside this time range.                        
+                        [ishomeFlagdetected, flgx] = flagTest(BIN, EVENTLIST, (les{kles}), mSeq,...
+                                jBin, targetLogItemArray(rcr) );  % call the function flagTest 12 March 2008
+                        [writeflag, writeindx] = writeTest(BIN, EVENTLIST, (les{kles}), mSeq, jBin,...
+                                targetLogPointer, writeflag, writeindx);
+                        if ishomeFlagdetected && ~flgx
+                                % And event code satisfied flag condition (by default) also...
+                                isdetectedLES = 0;
+                        elseif ishomeFlagdetected && flgx
+                                % Even worse, event code satisfied flag condition:
+                                isdetectedLES = 0;
+                        else
+                                % However, event code did not satisfy flag condition:
+                                isdetectedLES = 1;
+                        end
+                else
+                        % The pause was further away from the current code, so good news. Event code was found inside this time range.
+                        % Event code satisfied condition by time.
+                        [ishomeFlagdetected, flgx] = flagTest(BIN, EVENTLIST, (les{kles}), mSeq,...
+                                jBin, targetLogItemArray(rcr) );  % Call the function flagTest 12 March 2008
+                        [writeflag, writeindx] = writeTest(BIN, EVENTLIST, (les{kles}), mSeq, jBin,...
+                                targetLogPointer, writeflag, writeindx);
+                          
+                          
+                        %*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                        %*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                        %*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                        
+                        
+                        if ~ishomeFlagdetected   % BUG: isdetectedLES may not be declared!                              
+                                % event code did not satisfy flag condition:
+                                isdetectedLES = 0;
+                        end
+                        
+                        % Now, the Log item pointer (offsetLogitem), which moves around the detected
+                        % home logitem, is moved until the next successful detection by a time
+                        % criterion. This will imply that the sequencer's pointer (mSeq) will go
+                        % faster than offsetLogitem, for this bin
+                        
+                        offsetLogitem = abs(targetLogItemArray(rcr) - iLogitem);
+                        if targetLogPointer>1  &&  targetLogPointer<nitem
+                                previous_t2 = [EVENTLIST.eventinfo(targetLogItemArray(rcr) + traffic(kles)).time];
+                        end
+                end
+        end
+elseif israngedetected && ~isfrbddndetected   % Code was detected and there was no pause 04 February 2008
+        
+        %
+        % Stores the time of the detected logcode (within the time range)
+        %
+        timecodOK = targetLogTimeArray(rcr);
+        targetLogPointer = targetLogItemArray(rcr);
+        
+        [ishomeFlagdetected, flgx] = flagTest(BIN, EVENTLIST, (les{kles}), mSeq, jBin,...
+                targetLogItemArray(rcr) );
+        [writeflag, writeindx] = writeTest(BIN, EVENTLIST, (les{kles}), mSeq, jBin,...
+                targetLogPointer, writeflag, writeindx);
+        
+        if isnegated   % 02-21-2008
+                % We have a problem...event code was found inside this time range (%g).
+                
+                if EVENTLIST.eventinfo(targetLogItemArray(rcr)).enable  % checks enable  10-16-2008. Bug fixed Mar 28 2011
+                        if ishomeFlagdetected 
+                                isdetectedLES = 0;
+                        else
+                                % However, event code did not satisfy flag condition.
+                                isdetectedLES = 1;
+                        end
+                else  % checks enable  10-16-2008
+                        % However, event code is not enable.
+                        isdetectedLES = 1;
+                end
+        else
+                % Event code was found inside this time range. Event code satisfied condition by time.
+                
+                if EVENTLIST.eventinfo(targetLogItemArray(rcr)).enable  % checks enable  10-16-2008. Bug fixed Mar 28 2011
+                        if ishomeFlagdetected 
+                                isdetectedLES = 1;
+                        else
+                                % However, event code did not satisfy flag condition.
+                                isdetectedLES = 0;
+                        end
+                else  % checks enable  10-16-2008
+                        % However, event code is not enable.
+                        isdetectedLES = 0;
+                end
+                
+                % Now, the Log item pointer (offsetLogitem), which moves around the detected
+                % home logitem, is moved until the next successful detection by a time
+                % criterion. This will imply that the sequencer's pointer (mSeq) will go
+                % faster than offsetLogitem, for this bin
+                if isdetectedLES
+                        offsetLogitem = abs(targetLogItemArray(rcr) - iLogitem);
+                        if targetLogPointer>1 && targetLogPointer<nitem && ~islastsequencer
+                                previous_t2 = [EVENTLIST.eventinfo(targetLogItemArray(rcr) + traffic(kles)).time] ;
+                        end
+                end
+        end
+else   % event codes were not detected. Bad news?
+        if isnegated   % 02-21-2008
+                %Since event code is negated, and it was not found inside this time range, then good news.
+                isdetectedLES = 1;
+        else
+                %event code was not found inside this time range. Bad news.
+                isdetectedLES = 0;  % 12 March 2008
+        end
+end
+return

--- a/functions/pop_binlister_fast.m
+++ b/functions/pop_binlister_fast.m
@@ -1,0 +1,544 @@
+% PURPOSE  : Assign events to bins
+%
+% FORMAT   :
+%
+% EEG  = pop_binlister( EEG , parameters);
+%
+% INPUTS   :
+%
+% EEG           - input dataset
+%
+% The available parameters are as follows:
+%
+%     'BDF'         - name of the text file containing your bin descriptions (formulas).
+%     'ImportEL'	  - (optional) name of the text file, to import, that contain the event information to process,
+%                     according to ERPLAB format (see tutorial).
+%
+%     'ExportEL' 	  - (optional) name of the text file, to export, that will contain the upgraded event information,
+%                     according to ERPLAB format (see tutorial).
+
+%     'Resetflag'   - set (all) flags to zero before starting binlister process. 'on'=reset;  'off':keep as it is.
+%
+%     'Forbidden'	  - array of event codes (numeric). If any of these codes is among a set of codes successfully captured by a bin
+%                     this "capture" will be disable.
+%     'Ignore'      - array of event codes (numeric) to be ignored. Binlister will be blind to them.
+%
+%     'UpdateEEG'   - after binlister process you can move the upgraded event information to EEG.event field. 'on'=update, 'off'=keep as it is.
+%     'Warning'     - 'on'- warn if EVENTLIST will be overwritten. 'off' - do not warn if EVENTLIST will be overwritten.
+%     'SendEL2'     - once binlister ends its work, you can send a copy of the resulting EVENTLIST structure to:
+%                    'Text'           - send to text file
+%                    'EEG'            - send to EEG structure
+%                    'EEG&Text'       - send to EEG & text file
+%                    'Workspace'      - send to Matlab workspace,
+%                    'Workspace&Text' - send to Workspace and text file,
+%                    'Workspace&EEG'  - send to workspace and EEG,
+%                    'All'- send to all of them.
+%     'Report'      - 'on'= create report about binlister performance, 'off'= do not create a report.
+%     'Saveas'      - (optional) open GUI for saving dataset. 'on'/'off'
+%
+%
+%
+% OUTPUTS  :
+%
+% EEG            - updated output dataset
+%
+% EXAMPLE  :
+%
+% EEG  = pop_binlister( EEG , 'BDF', '/Users/etfoo/Documents/MATLAB/Test_Data/binlister_demo_2.txt', 'ExportEL', ...
+%                      '/Users/etfoo/Documents/MATLAB/Test_output.txt', 'Forbidden',  12, 'Ignore',  10, 'ImportEL',...
+%                      '/Users/etfoo/Documents/MATLAB/Test.txt', 'Saveas','on', 'SendEL2', 'All', 'UpdateEEG', 'on', 'Warning', 'on');
+%
+%
+% See also menuBinListGUI.m binlister.m
+%
+% *** This function is part of ERPLAB Toolbox ***
+% Author: Javier Lopez-Calderon and Steven Luck
+% Center for Mind and Brain
+% University of California, Davis,
+% Davis, CA
+% 2009
+
+%b8d3721ed219e65100184c6b95db209bb8d3721ed219e65100184c6b95db209b
+%
+% ERPLAB Toolbox
+% Copyright ? 2007 The Regents of the University of California
+% Created by Javier Lopez-Calderon and Steven Luck
+% Center for Mind and Brain, University of California, Davis,
+% javlopez@ucdavis.edu, sjluck@ucdavis.edu
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function [EEG, com] = pop_binlister_fast(EEG, varargin)
+global ALLEEG
+global CURRENTSET
+com = '';
+if nargin < 1
+        help pop_binlister
+        return
+end
+if isobject(EEG) % eegobj
+        whenEEGisanObject % calls a script for showing an error window
+        return
+end
+if nargin==1
+        if iseegstruct(EEG) && length(EEG)>1
+                msgboxText = 'Unfortunately, binlister does not work with multiple datasets';
+                title      = 'ERPLAB: multiple inputs';
+                errorfound(msgboxText, title);
+                return
+        end
+        if isfield(EEG.event, 'type')
+                if ~all(cellfun(@isnumeric, { EEG.event.type }))
+                        msgboxText = ['Some or all of your events contain only a text-based event label, '...
+                                'and not a numeric event code.  ERPLAB must have a numeric code '...
+                                'for every event (a text label can also be present).  For labels such as "S14", '...
+                                'you can automatically create an equivalent numeric event code (e.g., 14) by '...
+                                'checking the box labeled "Create numeric equivalents of nonnumeric event codes '...
+                                'when possible" when creating the EventList.\n\nFor labels that cannot be automatically '...
+                                'converted (e.g., "RESP"), or for ambiguous cases (e.g., when you have both "S14" and '...
+                                '"R14"), you can flexibly create numeric versions using the Advanced button at EVENTLIST GUI.'];
+                        title      = 'ERPLAB: Warning';
+                        errorfound(sprintf(msgboxText), title);
+                        return
+                end
+        end
+        def  = erpworkingmemory('pop_binlister');
+        if isempty(def)
+                def = {'' '' '' 0 [] [] 0 0 0 1 0};
+        end
+        try
+                ERPX = evalin('base', 'ERP');
+        catch
+                ERPX = [];
+        end
+        
+        %
+        % Call a GUI
+        %
+        packarray = menuBinListGUI(EEG, ERPX, def);
+        
+        if isempty(packarray)
+                disp('User selected Cancel')
+                return
+        end
+        
+        file1      = packarray{1};         % bin descriptor file
+        file2      = packarray{2};         % external eventlist (read event list from)
+        file3      = packarray{3};         % text file containing the updated EVENTLIST (Write resulting eventlist to)
+        flagrst    = packarray{4};         % 1 means reset flags
+        forbiddenCodeArray = packarray{5};
+        ignoreCodeArray    = packarray{6};
+        updevent   = packarray{7};
+        option2do  = packarray{8};         % See  option2do below
+        reportable = packarray{9};         % 1 means create a report about binlister work.
+        iswarning  = packarray{10};        % 1 means create a report about binlister work.
+        getfromerp = packarray{11};
+        indexEL    = packarray{12};
+        
+        if isempty(file2) || strcmpi(file2,'no') || strcmpi(file2,'none')
+                if getfromerp
+                        if isempty(ERPX)
+                                msgboxText =  'You do not have any loaded ERPset yet.';
+                                title = 'ERPLAB: no data';
+                                errorfound(msgboxText, title);
+                                return
+                        end
+                        EEGaux = EEG;
+                        EEG    = ERPX;
+                end
+                if isfield(EEG, 'EVENTLIST')
+                        %if length(EEG.EVENTLIST)>1
+                        %        prompt    = {'Enter  EVENLIST index:'};
+                        %        dlg_title = 'Multiple EVENTLIST at EEG were detected';
+                        %        num_lines = 1;
+                        %        def       = {'1'};
+                        %        answer    = inputvalue(prompt,dlg_title,num_lines,def);
+                        %        if isempty(answer)
+                        %                disp('User selected Cancel')
+                        %                return
+                        %        end
+                        %        indexEL = str2num(answer{1});
+                        %else
+                        %        indexEL = 1;
+                        %end
+                        
+                        if isfield(EEG.EVENTLIST, 'eventinfo')
+                                if isempty(EEG.EVENTLIST(indexEL).eventinfo)
+                                        msgboxText = ['EVENTLIST.eventinfo structure is empty!\n'...
+                                                'Use Create EVENTLIST before BINLISTER'];
+                                        title = 'ERPLAB: Error';
+                                        errorfound(sprintf(msgboxText), title);
+                                        return
+                                end
+                        else
+                                msgboxText =  ['EVENTLIST.eventinfo structure was not found!\n'...
+                                        'Use Create EVENTLIST before BINLISTER'];
+                                title = 'ERPLAB: Error';
+                                errorfound(sprintf(msgboxText), title);
+                                return
+                        end
+                else
+                        msgboxText =  ['EVENTLIST structure was not found!\n'...
+                                'Use Create EVENTLIST before BINLISTER'];
+                        title = 'ERPLAB: Error';
+                        errorfound(sprintf(msgboxText), title);
+                        return
+                end
+                logfilename = 'no';
+                logpathname = '';
+                file2 = [logpathname logfilename];
+                disp('For LOGFILE, user selected INTERNAL')
+        end
+        
+        erpworkingmemory('pop_binlister', {file1, file2, file3, flagrst, forbiddenCodeArray, ignoreCodeArray,...
+                updevent, option2do, reportable, iswarning, getfromerp, indexEL});
+        
+        if flagrst==1
+                strflagrst = 'on';
+        else
+                strflagrst = 'off';
+        end
+        if updevent==1
+                strupdevent = 'on';
+        else
+                strupdevent = 'off';
+        end
+        switch option2do
+                case 0
+                        msgboxText = 'Where should I send the update EVENTLIST???\n Pick an option.';
+                        title = 'ERPLAB: Error';
+                        errorfound(sprintf(msgboxText), title);
+                        return
+                case 1
+                        stroption2do = 'Text';
+                case 2
+                        stroption2do = 'EEG';
+                case 3
+                        stroption2do = 'EEG&Text';
+                case 4
+                        stroption2do = 'Workspace';
+                case 5
+                        stroption2do = 'Workspace&Text';
+                case 6
+                        stroption2do = 'Workspace&EEG';
+                case 7
+                        stroption2do = 'All';
+        end
+        if reportable==1
+                strreportable = 'on';
+        else
+                strreportable = 'off';
+        end
+        if iswarning==1
+                striswarning = 'on';
+        else
+                striswarning = 'off';
+        end
+        if ~getfromerp
+                EEG.setname = [EEG.setname '_bins']; %suggest a new name
+        end
+        
+        %
+        % Somersault
+        %
+        [EEG, com] = pop_binlister(EEG, 'BDF', file1, 'ImportEL', file2, 'ExportEL', file3, 'Resetflag', strflagrst, 'Forbidden', forbiddenCodeArray,...
+                'Ignore', ignoreCodeArray, 'UpdateEEG', strupdevent, 'SendEL2', stroption2do,'Report', strreportable, 'Warning', striswarning,...
+                'Saveas', 'on', 'IndexEL', indexEL, 'History', 'gui');
+        if getfromerp
+                EEG = EEGaux;
+        end
+        return
+end
+
+%
+% Parsing inputs
+%
+p = inputParser;
+p.FunctionName  = mfilename;
+p.CaseSensitive = false;
+p.addRequired('EEG');
+% option(s)
+p.addParamValue('BDF', '', @ischar);
+p.addParamValue('ImportEL', 'none', @ischar);
+p.addParamValue('ExportEL', 'none', @ischar);
+p.addParamValue('Resetflag', 'off', @ischar);% 'on', 'off'
+p.addParamValue('Forbidden', [], @isnumeric);
+p.addParamValue('Ignore', [], @isnumeric);
+p.addParamValue('UpdateEEG', 'off', @ischar);% 'on', 'off'
+p.addParamValue('SendEL2', 'EEG', @ischar);  %
+p.addParamValue('Report', 'off', @ischar);   % 'on', 'off'
+p.addParamValue('Warning', 'off', @ischar);  % 'on', 'off'
+p.addParamValue('Saveas', 'off', @ischar);   % 'on', 'off'
+p.addParamValue('IndexEL', 1, @isnumeric);   % integer
+p.addParamValue('Voutput', 'EEG', @ischar);  % 'EEG' (which contains EVENTLIST) or 'EVENTLIST' (EVENTLIST only)
+p.addParamValue('History', 'script', @ischar); % history from scripting
+
+p.parse(EEG, varargin{:});
+
+if length(EEG)>1
+        msgboxText =  'ERPLAB says: Unfortunately, this function does not work with multiple datasets';
+        error(msgboxText);
+end
+
+file1      = p.Results.BDF;              % bin descriptor file
+file2      = p.Results.ImportEL;         % external eventlist (read event list from)
+file3      = p.Results.ExportEL;         % text file containing the updated EVENTLIST (Write resulting eventlist to)
+indexEL    = p.Results.IndexEL;          % EVENTLIST's index (in case of multiple EVENTLISTs)
+outputv    = p.Results.Voutput;          % 'EEG' (which contains EVENTLIST) or 'EVENTLIST' (EVENTLIST only)
+
+if strcmpi(p.Results.Resetflag, 'on')
+        flagrst = 1;
+else
+        flagrst = 0;
+end
+if strcmpi(p.Results.Warning, 'on')
+        iswarning = 1;
+else
+        iswarning = 0;
+end
+switch p.Results.SendEL2
+        case 'Text'
+                option2do = 1;
+        case 'EEG'
+                option2do = 2;
+        case 'EEG&Text'
+                option2do = 3;
+        case 'Workspace'
+                option2do = 4;
+        case 'Workspace&Text'
+                option2do = 5;
+        case 'Workspace&EEG'
+                option2do = 6;
+        case {'All', 'Workspace&EEG&Text', 'Workspace&Text&EEG', 'EEG&Text&Workspace', 'EEG&Workspace&Text', 'Text&Workspace&EEG', 'Text&EEG&Workspace'}
+                option2do = 7;
+        otherwise
+                %option2do = 0;
+                error('ERPLAB says: You must specify what to do with the updated EVENTLIST.')
+end
+if isempty(file2) || strcmpi(file2,'no') || strcmpi(file2,'none')
+        if isfield(EEG, 'EVENTLIST')
+                if isfield(EEG.EVENTLIST, 'eventinfo')
+                        if isempty(EEG.EVENTLIST(indexEL).eventinfo)
+                                msgboxText = ['ERPLAB says: EVENTLIST.eventinfo structure is empty!\n'...
+                                        'Use Create EVENTLIST before BINLISTER'];
+                                error(sprintf(msgboxText));
+                        end
+                else
+                        msgboxText =  ['ERPLAB says: EVENTLIST.eventinfo structure was not found!\n'...
+                                'Use Create EVENTLIST before BINLISTER'];
+                        error(sprintf(msgboxText));
+                end
+        else
+                msgboxText =  ['ERPLAB says: EVENTLIST structure was not found!\n'...
+                        'Use Create EVENTLIST before BINLISTER'];
+                error(sprintf(msgboxText));
+        end
+        if ~isempty(EEG.EVENTLIST(indexEL)) && iswarning==1
+                binaux    = [EEG.EVENTLIST(indexEL).eventinfo.bini];
+                binhunter = binaux(binaux>0); %8/19/2009
+                
+                if ~isempty(binhunter) && ismember_bc2(option2do, [2 3 6 7])
+                        msgboxText =  ['This dataset already has assigned bins.\n'...;
+                                'Would you like to overwrite these bins?'];
+                        title = 'ERPLAB: WARNING';
+                        button =askquest(sprintf(msgboxText), title);
+                        if strcmpi(button,'no')
+                                disp('User canceled')
+                                return
+                        end
+                end
+        end
+        
+        %
+        % Check for alphanumeric event codes
+        %
+        codelist = {EEG.EVENTLIST(indexEL).eventinfo.code};
+        if nnz(cellfun(@ischar, codelist))>0
+                msgboxText = ['Your dataset still has alphanumeric/string codes.\n\n'...
+                        'You may try either eliminating nonnumeric information (see Create EVENTLIST)\n'...
+                        'or remapping your events (see Create EVENTLIST Advanced)'];
+                %title = 'ERPLAB: BDF Parsing Error';
+                %errorfound(sprintf(msgboxText), title);
+                %return
+                error(msgboxText);
+        end
+        % save original EVENTLIST
+        %ELaux = EEG.EVENTLIST(indexEL); % store original EVENTLIST
+        
+        %
+        %  Reset Flags?
+        %
+        if flagrst==1
+                % reset artifact flags
+                EEG = resetflag(EEG, 255, indexEL);
+        elseif flagrst==2
+                % reset user flags
+                EEG = resetflag(EEG, 65280, indexEL);
+        elseif flagrst==3
+                % reset ALL flags
+                EEG = resetflag(EEG, indexEL);
+        end
+end
+
+forbiddenCodeArray = p.Results.Forbidden;
+ignoreCodeArray    = p.Results.Ignore;
+
+if strcmpi(p.Results.UpdateEEG, 'on')
+        updevent = 1;
+else
+        updevent = 0;
+end
+if strcmpi(p.Results.Report, 'on')
+        reportable = 1;
+else
+        reportable = 0;
+end
+if ismember_bc2({p.Results.Saveas}, {'on','yes'})
+        issaveas    = 1;
+else
+        issaveas    = 0;
+end
+if strcmpi(outputv, 'EVENTLIST') || strcmpi(outputv, 'EL')
+        Voutput = 1; % EVENTLIST
+else
+        Voutput = 0; % EEG
+end
+if strcmpi(p.Results.History,'implicit')
+        shist = 3; % implicit
+elseif strcmpi(p.Results.History,'script')
+        shist = 2; % script
+elseif strcmpi(p.Results.History,'gui')
+        shist = 1; % gui
+else
+        shist = 0; % off
+end
+
+%
+% subroutine
+%
+%
+% Call (neo)binlister
+%
+if reportable % workaround for a faster binlister... 02/28/12 JLC
+        [EEG, EVENTLIST, binofbins, isparsenum] = binlister(EEG, file1, file2, file3, forbiddenCodeArray, ignoreCodeArray, reportable);
+else
+        [EEG, EVENTLIST, binofbins, isparsenum] = neobinlister2_fast(EEG, file1, file2, file3, forbiddenCodeArray, ignoreCodeArray, 0);
+end
+if isparsenum==0
+        % parsing was not approved
+        msgboxText = ['Bin descriptor file contains errors!\n'...
+                'For details, please read command window messages.'];
+        title = 'ERPLAB: BDF Parsing Error';
+        errorfound(sprintf(msgboxText), title);
+        %EEG.EVENTLIST(indexEL) = ELaux;
+        return
+end
+if nnz(binofbins)>=1
+        if ~isempty(EVENTLIST)
+                if Voutput==1 % EVENTLIST is the output only (for scripting)
+                        clear EEG
+                        EEG = EVENTLIST;
+                        return
+                end
+                if iseegstruct(EEG) && ismember_bc2(option2do, [2 3 6 7])
+                        EEG =  pasteeventlist(EEG, EVENTLIST, 1, indexEL);
+                        if updevent && issaveas
+                                EEG = pop_overwritevent(EEG, 'code', 'History', 'off');
+                        elseif updevent && ~issaveas
+                                EEG = pop_overwritevent(EEG, 'code', 'History', 'off');
+                        end
+                end
+                if ismember_bc2(option2do, [4 5 6 7])
+                        assignin('base','EVENTLIST',EVENTLIST);  % send EVENTLIST structure to WORKSPACE, August 22, 2008
+                        disp('EVENTLIST structure was sent to WORKSPACE.')
+                end
+                if ismember_bc2(option2do, [1 3 5 7]) && ~isempty(file2) && ~strcmpi(file2,'no') && ~strcmpi(file2,'none')
+                        disp('A text file version of your EVENTLIST was created.')
+                end
+                
+                %
+                % Generate equivalent command (for history)
+                %
+                skipfields = {'EEG', 'ERP', 'Saveas', 'Warning', 'History'};
+                fn  = fieldnames(p.Results);
+                com = sprintf( '%s  = %s( %s ', inputname(1), mfilename, inputname(1));
+                for q=1:length(fn)
+                        fn2com = fn{q};
+                        if ~ismember_bc2(fn2com, skipfields)
+                                fn2res = p.Results.(fn2com);
+                                if ~isempty(fn2res)
+                                        if ischar(fn2res)
+                                                if ~strcmpi(fn2res,'off') && ~strcmpi(fn2res,'no') && ~strcmpi(fn2res,'none')
+                                                        com = sprintf( '%s, ''%s'', ''%s''', com, fn2com, fn2res);
+                                                end
+                                        else
+                                                if iscell(fn2res)
+                                                        fn2resstr = vect2colon(cell2mat(fn2res), 'Sort','on');
+                                                        fnformat = '{%s}';
+                                                else
+                                                        fn2resstr = vect2colon(fn2res, 'Sort','on');
+                                                        fnformat = '%s';
+                                                end
+                                                com = sprintf( ['%s, ''%s'', ' fnformat], com, fn2com, fn2resstr);
+                                        end
+                                end
+                        end
+                end
+                com = sprintf( '%s );', com);
+        else
+                msgboxText = ['Bin descriptor file contains errors!\n'...
+                        'For details, please read command window messages.'];
+                title = 'ERPLAB: BDF Parsing Error';
+                errorfound(sprintf(msgboxText), title);
+                EEG.EVENTLIST(indexEL) = ELaux;
+                return
+        end
+else
+        msgboxText =  ['Bins were not found!\n'...
+                'Try with other BDF or modify the current one.'];
+        title = 'ERPLAB: Binlister Error';
+        errorfound(sprintf(msgboxText), title);
+        disp('binlister process was cancel.')
+        %EEG.EVENTLIST(indexEL) = ELaux;
+        return
+end
+% get history from script. EEG
+switch shist
+        case 1 % from GUI
+                com = sprintf('%s %% GUI: %s', com, datestr(now));
+                %fprintf('%%Equivalent command:\n%s\n\n', com);
+                displayEquiComERP(com);
+        case 2 % from script
+                EEG = erphistory(EEG, [], com, 1);
+        case 3
+                % implicit
+        otherwise %off or none
+                com = '';
+end
+
+%
+% Completion statement
+%
+msg2end
+
+if issaveas && ismember_bc2(option2do, [2 3 6 7]) && iseegstruct(EEG)
+        [ALLEEG, EEG, CURRENTSET] = pop_newset( ALLEEG, EEG, CURRENTSET);
+end
+if exist('ALLEEG', 'var')
+        if ~isfield(ALLEEG,'data')
+                [ALLEEG(1:length(ALLEEG)).data] = deal([]);
+        end
+end
+return
+


### PR DESCRIPTION
Hi!
I re-wrote a section of the neobinlister2, now available as additional function "neobinlister2_fast" with its own pop_neobinlister2_fast, to speed it up. In particular when working with combined EEG and eye-tracking data, many events can be present in a dataset (up to 15.000-20.000). This new version is about 50-100 times faster than the old version, which is quite a significant speed-up. Please add this function to the ERPLAB. It does, however, not yet support RT measurement, and forbidden/ignoreCodeArray functions, and some other things have yet to be tested more extensively, I guess. In one test dataset, I get, however, exactly the same result as with the previous neobinlister2 version.
Cheers,
Christoph